### PR TITLE
this should fix error when running build.py on python>3.8

### DIFF
--- a/docs/themes/mynewt/layout.html
+++ b/docs/themes/mynewt/layout.html
@@ -35,7 +35,7 @@
 
     {# CSS #}
 
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/' + styles[-1], 1) }}" type="text/css" />
 
     {% for cssfile in css_files %}
       <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />


### PR DESCRIPTION
 sh.ErrorReturnCode_2:
|
|   RAN: /usr/bin/make docs 'O=-A cur_version=master -A latest_version=1.13.0'